### PR TITLE
2 user registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.0.2"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.6"
 
+gem 'pry', '~> 0.13.1'
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
 
@@ -46,3 +47,7 @@ group :development do
   # gem "spring"
 end
 
+
+gem "authentication-zero", "~> 2.16"
+# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
+gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,9 +66,12 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    authentication-zero (2.16.36)
+    bcrypt (3.1.19)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -109,6 +112,9 @@ GEM
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     puma (5.6.6)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -159,9 +165,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  authentication-zero (~> 2.16)
+  bcrypt (~> 3.1.7)
   bootsnap
   debug
   pg (~> 1.1)
+  pry (~> 0.13.1)
   puma (~> 5.0)
   rails (~> 7.0.6)
   tzinfo-data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,20 @@
 class ApplicationController < ActionController::API
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
+  before_action :set_current_request_details
+  before_action :authenticate
+
+  private
+    def authenticate
+      if session_record = authenticate_with_http_token { |token, _| Session.find_signed(token) }
+        Current.session = session_record
+      else
+        request_http_token_authentication
+      end
+    end
+
+    def set_current_request_details
+      Current.user_agent = request.user_agent
+      Current.ip_address = request.ip
+    end
 end

--- a/app/controllers/identity/email_verifications_controller.rb
+++ b/app/controllers/identity/email_verifications_controller.rb
@@ -1,0 +1,20 @@
+class Identity::EmailVerificationsController < ApplicationController
+  skip_before_action :authenticate, only: :show
+
+  before_action :set_user, only: :show
+
+  def show
+    @user.update!(verified: true); head(:no_content)
+  end
+
+  def create
+    UserMailer.with(user: Current.user).email_verification.deliver_later
+  end
+
+  private
+    def set_user
+      token = EmailVerificationToken.find_signed!(params[:sid]); @user = token.user
+    rescue StandardError
+      render json: { error: "That email verification link is invalid" }, status: :bad_request
+    end
+end

--- a/app/controllers/identity/emails_controller.rb
+++ b/app/controllers/identity/emails_controller.rb
@@ -1,0 +1,30 @@
+class Identity::EmailsController < ApplicationController
+  before_action :set_user
+
+  def update
+    if !@user.authenticate(params[:current_password])
+      render json: { error: "The password you entered is incorrect" }, status: :bad_request
+    elsif @user.update(email: params[:email])
+      render_show
+    else
+      render json: @user.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def set_user
+      @user = Current.user
+    end
+
+    def render_show
+      if @user.email_previously_changed?
+        resend_email_verification; render(json: @user)
+      else
+        render json: @user
+      end
+    end
+
+    def resend_email_verification
+      UserMailer.with(user: @user).email_verification.deliver_later
+    end
+end

--- a/app/controllers/identity/password_resets_controller.rb
+++ b/app/controllers/identity/password_resets_controller.rb
@@ -1,0 +1,40 @@
+class Identity::PasswordResetsController < ApplicationController
+  skip_before_action :authenticate
+
+  before_action :set_user, only: :update
+
+  def edit
+    head :no_content
+  end
+
+  def create
+    if @user = User.find_by(email: params[:email], verified: true)
+      UserMailer.with(user: @user).password_reset.deliver_later
+    else
+      render json: { error: "You can't reset your password until you verify your email" }, status: :bad_request
+    end
+  end
+
+  def update
+    if @user.update(user_params)
+      revoke_tokens; render(json: @user)
+    else
+      render json: @user.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def set_user
+      token = PasswordResetToken.find_signed!(params[:sid]); @user = token.user
+    rescue StandardError
+      render json: { error: "That password reset link is invalid" }, status: :bad_request
+    end
+
+    def user_params
+      params.permit(:password, :password_confirmation)
+    end
+
+    def revoke_tokens
+      @user.password_reset_tokens.delete_all
+    end
+end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,22 @@
+class PasswordsController < ApplicationController
+  before_action :set_user
+
+  def update
+    if !@user.authenticate(params[:current_password])
+      render json: { error: "The current password you entered is incorrect" }, status: :bad_request
+    elsif @user.update(user_params)
+      render json: @user
+    else
+      render json: @user.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def set_user
+      @user = Current.user
+    end
+
+    def user_params
+      params.permit(:password, :password_confirmation)
+    end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,23 @@
+class RegistrationsController < ApplicationController
+  skip_before_action :authenticate
+
+  def create
+    @user = User.new(user_params)
+
+    if @user.save
+      send_email_verification
+      render json: @user, status: :created
+    else
+      render json: @user.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def user_params
+      params.permit(:email, :password, :password_confirmation)
+    end
+
+    def send_email_verification
+      UserMailer.with(user: @user).email_verification.deliver_later
+    end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,34 @@
+class SessionsController < ApplicationController
+  skip_before_action :authenticate, only: :create
+
+  before_action :set_session, only: %i[ show destroy ]
+
+  def index
+    render json: Current.user.sessions.order(created_at: :desc)
+  end
+
+  def show
+    render json: @session
+  end
+
+  def create
+    user = User.find_by(email: params[:email])
+
+    if user && user.authenticate(params[:password])
+      @session = user.sessions.create!
+      response.set_header "X-Session-Token", @session.signed_id
+      render json: @session, status: :created
+    else
+      render json: { error: "That email or password is incorrect" }, status: :unauthorized
+    end
+  end
+
+  def destroy
+    @session.destroy
+  end
+
+  private
+    def set_session
+      @session = Current.user.sessions.find(params[:id])
+    end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,15 @@
+class UserMailer < ApplicationMailer
+  def password_reset
+    @user = params[:user]
+    @signed_id = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
+
+    mail to: @user.email, subject: "Reset your password"
+  end
+
+  def email_verification
+    @user = params[:user]
+    @signed_id = @user.email_verification_tokens.create.signed_id(expires_in: 2.days)
+
+    mail to: @user.email, subject: "Verify your email"
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,6 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :session
+  attribute :user_agent, :ip_address
+
+  delegate :user, to: :session, allow_nil: true
+end

--- a/app/models/email_verification_token.rb
+++ b/app/models/email_verification_token.rb
@@ -1,0 +1,3 @@
+class EmailVerificationToken < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/password_reset_token.rb
+++ b/app/models/password_reset_token.rb
@@ -1,0 +1,3 @@
+class PasswordResetToken < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,8 @@
+class Session < ApplicationRecord
+  belongs_to :user
+
+  before_create do
+    self.user_agent = Current.user_agent
+    self.ip_address = Current.ip_address
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,22 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  has_many :email_verification_tokens, dependent: :destroy
+  has_many :password_reset_tokens, dependent: :destroy
+  has_many :sessions, dependent: :destroy
+
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :password, allow_nil: true, length: { minimum: 8 }
+
+  before_validation if: -> { email.present? } do
+    self.email = email.downcase.strip
+  end
+
+  before_validation if: :email_changed?, on: :update do
+    self.verified = false
+  end
+
+  after_update if: :password_digest_previously_changed? do
+    sessions.where.not(id: Current.session).delete_all
+  end
+end

--- a/app/views/user_mailer/email_verification.html.erb
+++ b/app/views/user_mailer/email_verification.html.erb
@@ -1,0 +1,11 @@
+<p>Hey there,</p>
+
+<p>This is to confirm that <%= @user.email %> is the email you want to use on your account. If you ever lose your password, that's where we'll email a reset link.</p>
+
+<p><strong>You must hit the link below to confirm that you received this email.</strong></p>
+
+<p><%= link_to "Yes, use this email for my account", identity_email_verification_url(sid: @signed_id) %></p>
+
+<hr>
+
+<p>Have questions or need help? Just reply to this email and our support team will help you sort it out.</p>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,11 @@
+<p>Hey there,</p>
+
+<p>Can't remember your password for <strong><%= @user.email %></strong>? That's OK, it happens. Just hit the link below to set a new one.</p>
+
+<p><%= link_to "Reset my password", edit_identity_password_reset_url(sid: @signed_id) %></p>
+
+<p>If you did not request a password reset you can safely ignore this email, it expires in 20 minutes. Only someone with access to this email account can reset your password.</p>
+
+<hr>
+
+<p>Have questions or need help? Just reply to this email and our support team will help you sort it out.</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,7 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,13 @@
 Rails.application.routes.draw do
+  post "sign_in", to: "sessions#create"
+  post "sign_up", to: "registrations#create"
+  resources :sessions, only: [:index, :show, :destroy]
+  resource  :password, only: [:edit, :update]
+  namespace :identity do
+    resource :email,              only: [:edit, :update]
+    resource :email_verification, only: [:show, :create]
+    resource :password_reset,     only: [:new, :edit, :create, :update]
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")

--- a/db/migrate/20230801172256_create_users.rb
+++ b/db/migrate/20230801172256_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :email,           null: false, index: { unique: true }
+      t.string :password_digest, null: false
+
+      t.boolean :verified, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230801172257_create_sessions.rb
+++ b/db/migrate/20230801172257_create_sessions.rb
@@ -1,0 +1,11 @@
+class CreateSessions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :user_agent
+      t.string :ip_address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230801172258_create_password_reset_tokens.rb
+++ b/db/migrate/20230801172258_create_password_reset_tokens.rb
@@ -1,0 +1,7 @@
+class CreatePasswordResetTokens < ActiveRecord::Migration[7.0]
+  def change
+    create_table :password_reset_tokens do |t|
+      t.references :user, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20230801172259_create_email_verification_tokens.rb
+++ b/db/migrate/20230801172259_create_email_verification_tokens.rb
@@ -1,0 +1,7 @@
+class CreateEmailVerificationTokens < ActiveRecord::Migration[7.0]
+  def change
+    create_table :email_verification_tokens do |t|
+      t.references :user, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,48 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_08_01_172259) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "email_verification_tokens", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_email_verification_tokens_on_user_id"
+  end
+
+  create_table "password_reset_tokens", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_password_reset_tokens_on_user_id"
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "user_agent"
+    t.string "ip_address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.boolean "verified", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "email_verification_tokens", "users"
+  add_foreign_key "password_reset_tokens", "users"
+  add_foreign_key "sessions", "users"
+end

--- a/test/controllers/identity/email_verifications_controller_test.rb
+++ b/test/controllers/identity/email_verifications_controller_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class Identity::EmailVerificationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user, @token = sign_in_as(users(:lazaro_nixon))
+    @user.update! verified: false
+  end
+
+  def default_headers
+    { "Authorization" => "Bearer #{@token}" }
+  end
+
+  test "should send a verification email" do
+    assert_enqueued_email_with UserMailer, :email_verification, args: { user: @user } do
+      post identity_email_verification_url, headers: default_headers
+    end
+
+    assert_response :no_content
+  end
+
+  test "should verify email" do
+    sid = @user.email_verification_tokens.create.signed_id(expires_in: 2.days)
+
+    get identity_email_verification_url, params: { sid: sid }, headers: default_headers
+    assert_response :no_content
+  end
+
+  test "should not verify email with expired token" do
+    sid_exp = @user.email_verification_tokens.create.signed_id(expires_in: 0.minutes)
+
+    get identity_email_verification_url, params: { sid: sid_exp }, headers: default_headers
+    assert_response :bad_request
+    assert_equal "That email verification link is invalid", response.parsed_body["error"]
+  end
+end

--- a/test/controllers/identity/emails_controller_test.rb
+++ b/test/controllers/identity/emails_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Identity::EmailsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user, @token = sign_in_as(users(:lazaro_nixon))
+  end
+
+  def default_headers
+    { "Authorization" => "Bearer #{@token}" }
+  end
+
+  test "should update email" do
+    patch identity_email_url, params: { email: "new_email@hey.com", current_password: "Secret1*3*5*" }, headers: default_headers
+    assert_response :success
+  end
+
+  test "should not update email with wrong current password" do
+    patch identity_email_url, params: { email: "new_email@hey.com", current_password: "SecretWrong1*3" }, headers: default_headers
+
+    assert_response :bad_request
+    assert_equal "The password you entered is incorrect", response.parsed_body["error"]
+  end
+end

--- a/test/controllers/identity/password_resets_controller_test.rb
+++ b/test/controllers/identity/password_resets_controller_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:lazaro_nixon)
+  end
+
+  test "should get edit" do
+    sid = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
+
+    get edit_identity_password_reset_url(sid: sid)
+    assert_response :no_content
+  end
+
+  test "should send a password reset email" do
+    assert_enqueued_email_with UserMailer, :password_reset, args: { user: @user } do
+      post identity_password_reset_url, params: { email: @user.email }
+    end
+
+    assert_response :no_content
+  end
+
+  test "should not send a password reset email to a nonexistent email" do
+    assert_no_enqueued_emails do
+      post identity_password_reset_url, params: { email: "invalid_email@hey.com" }
+    end
+
+    assert_response :bad_request
+    assert_equal "You can't reset your password until you verify your email", response.parsed_body["error"]
+  end
+
+  test "should not send a password reset email to a unverified email" do
+    @user.update! verified: false
+
+    assert_no_enqueued_emails do
+      post identity_password_reset_url, params: { email: @user.email }
+    end
+
+    assert_response :bad_request
+    assert_equal "You can't reset your password until you verify your email", response.parsed_body["error"]
+  end
+
+  test "should update password" do
+    sid = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
+
+    patch identity_password_reset_url, params: { sid: sid, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }
+    assert_response :success
+  end
+
+  test "should not update password with expired token" do
+    sid_exp = @user.password_reset_tokens.create.signed_id(expires_in: 0.minutes)
+
+    patch identity_password_reset_url, params: { sid: sid_exp, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }
+    assert_response :bad_request
+    assert_equal "That password reset link is invalid", response.parsed_body["error"]
+  end
+end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class PasswordsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user, @token = sign_in_as(users(:lazaro_nixon))
+  end
+
+  def default_headers
+    { "Authorization" => "Bearer #{@token}" }
+  end
+
+  test "should update password" do
+    patch password_url, params: { current_password: "Secret1*3*5*", password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }, headers: default_headers
+    assert_response :success
+  end
+
+  test "should not update password with wrong current password" do
+    patch password_url, params: { current_password: "SecretWrong1*3", password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }, headers: default_headers
+
+    assert_response :bad_request
+    assert_equal "The current password you entered is incorrect", response.parsed_body["error"]
+  end
+end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  test "should sign up" do
+    assert_difference("User.count") do
+      post sign_up_url, params: { email: "lazaronixon@hey.com", password: "Secret1*3*5*", password_confirmation: "Secret1*3*5*" }
+    end
+
+    assert_response :created
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user, @token = sign_in_as(users(:lazaro_nixon))
+  end
+
+  def default_headers
+    { "Authorization" => "Bearer #{@token}" }
+  end
+
+  test "should get index" do
+    get sessions_url, headers: default_headers
+    assert_response :success
+  end
+
+  test "should show session" do
+    get session_url(@user.sessions.last), headers: default_headers
+    assert_response :success
+  end
+
+  test "should sign in" do
+    post sign_in_url, params: { email: @user.email, password: "Secret1*3*5*" }
+    assert_response :created
+  end
+
+  test "should not sign in with wrong credentials" do
+    post sign_in_url, params: { email: @user.email, password: "SecretWrong1*3" }
+    assert_response :unauthorized
+  end
+
+  test "should sign out" do
+    delete session_url(@user.sessions.last), headers: default_headers
+    assert_response :no_content
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,6 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+lazaro_nixon:
+  email: lazaronixon@hotmail.com
+  password_digest: <%= BCrypt::Password.create("Secret1*3*5*") %>
+  verified: true

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class UserMailerTest < ActionMailer::TestCase
+  setup do
+    @user = users(:lazaro_nixon)
+  end
+
+  test "password_reset" do
+    mail = UserMailer.with(user: @user).password_reset
+    assert_equal "Reset your password", mail.subject
+    assert_equal [@user.email], mail.to
+  end
+
+  test "email_verification" do
+    mail = UserMailer.with(user: @user).email_verification
+    assert_equal "Verify your email", mail.subject
+    assert_equal [@user.email], mail.to
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,4 +10,7 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  def sign_in_as(user)
+    post(sign_in_url, params: { email: user.email, password: "Secret1*3*5*" }); [user, response.headers["X-Session-Token"]]
+  end
 end


### PR DESCRIPTION
2 important POST endpoints added with this PR: `http://localhost:3000/sign_up` and `http://localhost:3000/sign_in`

On successful sign-in, a X-Session-Token header is provided. This is passed as a bearer token to authenticate a user's actions in controllers

